### PR TITLE
Product page

### DIFF
--- a/schemas/documents/products.js
+++ b/schemas/documents/products.js
@@ -1,0 +1,63 @@
+export default {
+	name: 'products',
+	title: 'Products',
+	type: 'document',
+	fieldsets: [
+		{
+			name: 'metadata',
+			title: 'SEO & metadata',
+		},
+	],
+	fields: [
+		{
+			name: 'title',
+			type: 'string',
+			title: 'Title',
+			validation: (Rule) => Rule.required(),
+		},
+		{
+			name: 'hero',
+			title: 'Hero',
+			type: 'hero',
+		},
+		{
+			name: 'threeColumnSection',
+			title: 'Three Column Section',
+			type: 'threeColumnSection',
+		},
+		{
+			name: 'productAccordion',
+			title: 'Product Accordion',
+			type: 'productAccordion',
+		},
+		{
+			name: 'productAccordion2',
+			title: 'Product Accordion 2',
+			type: 'productAccordion',
+		},
+		{
+			name: 'disclaimer',
+			type: 'text',
+		},
+		{
+			name: 'description',
+			type: 'text',
+			title: 'Description',
+			description: 'This description populates meta-tags on the webpage',
+			fieldset: 'metadata',
+		},
+		{
+			name: 'openGraphImage',
+			type: 'image',
+			title: 'Open Graph Image',
+			description: 'Image for sharing previews on Facebook, Twitter etc.',
+			fieldset: 'metadata',
+		},
+	],
+	preview: {
+		select: {
+			title: 'title',
+			media: 'openGraphImage',
+		},
+	},
+};

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -36,6 +36,9 @@ import documentCategory from './objects/documentCategory';
 import regulationItem from './objects/documentItem';
 import threeColumnSection from './objects/threeColumnSection';
 import sectionHeading from './objects/sectionHeading';
+import productAccordion from './objects/productAccordion';
+import productAccordionItem from './objects/productAccordionItem';
+import products from './documents/products';
 
 export const schemaTypes = [
 	// Document types
@@ -75,4 +78,7 @@ export const schemaTypes = [
 	documentCategory,
 	threeColumnSection,
 	sectionHeading,
+	productAccordion,
+	productAccordionItem,
+	products,
 ];

--- a/schemas/objects/productAccordion.js
+++ b/schemas/objects/productAccordion.js
@@ -1,0 +1,60 @@
+export default {
+	name: 'productAccordion',
+	title: 'Product Accordion',
+	type: 'object',
+	fields: [
+		{
+			name: 'heading',
+			title: 'Heading',
+			type: 'string',
+		},
+		{
+			name: 'text',
+			title: 'Text',
+			type: 'array',
+			of: [{ type: 'block' }],
+		},
+		{
+			name: 'sharedImage',
+			title: 'Shared Image',
+			type: 'boolean',
+			description:
+				'When enabled, a single shared image is displayed for all accordion items. When disabled, each item uses its own image.',
+			initialValue: false,
+		},
+		{
+			name: 'image',
+			title: 'Image',
+			type: 'image',
+			options: {
+				hotspot: true,
+			},
+			fields: [
+				{
+					name: 'alt',
+					title: 'Alternative Text',
+					type: 'string',
+					description: 'Important for SEO and accessibility',
+				},
+			],
+			hidden: ({ parent }) => !parent?.sharedImage,
+		},
+		{
+			name: 'items',
+			title: 'Accordion Items',
+			type: 'array',
+			of: [{ type: 'productAccordionItem' }],
+		},
+	],
+	preview: {
+		select: {
+			heading: 'heading',
+		},
+		prepare({ heading }) {
+			return {
+				title: heading,
+				subtitle: 'Product Accordion',
+			};
+		},
+	},
+};

--- a/schemas/objects/productAccordionItem.js
+++ b/schemas/objects/productAccordionItem.js
@@ -20,6 +20,12 @@ export default {
 			of: [{ type: 'block' }],
 		},
 		{
+			name: 'hasDisclaimer',
+			title: 'Has Disclaimer',
+			type: 'boolean',
+			initialValue: false,
+		},
+		{
 			name: 'image',
 			title: 'Image',
 			type: 'image',

--- a/schemas/objects/productAccordionItem.js
+++ b/schemas/objects/productAccordionItem.js
@@ -1,0 +1,53 @@
+export default {
+	name: 'productAccordionItem',
+	title: 'Product Accordion Item',
+	type: 'object',
+	fields: [
+		{
+			name: 'title',
+			title: 'Title',
+			type: 'string',
+		},
+		{
+			name: 'subtitle',
+			title: 'Subtitle',
+			type: 'string',
+		},
+		{
+			name: 'description',
+			title: 'Description',
+			type: 'array',
+			of: [{ type: 'block' }],
+		},
+		{
+			name: 'image',
+			title: 'Image',
+			type: 'image',
+			options: {
+				hotspot: true,
+			},
+			fields: [
+				{
+					name: 'alt',
+					title: 'Alternative Text',
+					type: 'string',
+					description: 'Important for SEO and accessibility',
+				},
+			],
+		},
+	],
+	preview: {
+		select: {
+			title: 'title',
+			subtitle: 'subtitle',
+			media: 'image',
+		},
+		prepare({ title, subtitle, media }) {
+			return {
+				title,
+				subtitle,
+				media,
+			};
+		},
+	},
+};

--- a/structure.js
+++ b/structure.js
@@ -22,6 +22,7 @@ const hiddenDocTypes = (listItem) =>
 		'trading',
 		'regulatory',
 		'teamMemberDoc',
+		'products',
 	].includes(listItem.getId());
 
 export const structure = structureTool({
@@ -33,6 +34,7 @@ export const structure = structureTool({
 			.items([
 				S.documentListItem().id('home').schemaType('home').title('Home'),
 				S.documentListItem().id('givingBack').schemaType('givingBack').title('About'),
+				S.documentListItem().id('products').schemaType('products').title('Products'),
 				S.documentListItem().id('news').schemaType('news').title('News'),
 				S.documentListItem().id('team').schemaType('team').title('Team'),
 				S.documentListItem().id('careers').schemaType('careers').title('Careers'),


### PR DESCRIPTION
New document type: products                                                                                                                                     
  
  - schemas/documents/products.js — A new products document schema with fields for:                                                                               
    - Title (required)
    - Hero section (reuses existing hero type)                                                                                                                    
    - Three column section (reuses existing threeColumnSection type)
    - Two product accordion sections (productAccordion and productAccordion2)                                                                                     
    - Disclaimer text                                                                                                                                             
    - SEO metadata (description + Open Graph image)                                                                                                               
                                                                                                                                                                  
  New object types                                                                                                                                                
  
  - schemas/objects/productAccordion.js — An accordion component with heading, rich text, an optional shared image (toggled by a boolean), and an array of        
  accordion items.
  - schemas/objects/productAccordionItem.js — Individual accordion items with title, subtitle, rich text description, a "has disclaimer" boolean, and an image    
  with alt text.                                                                                                                                                  
  
  Wiring it up                                                                                                                                                    
                  
  - schemas/index.js — Registered the 3 new types (products, productAccordion, productAccordionItem).                                                             
  - structure.js — Added products to the hidden doc types list and added a singleton "Products" entry in the Studio desk structure (between "About" and "News").